### PR TITLE
refactor: adjusted handlers

### DIFF
--- a/backend/src/database/users.go
+++ b/backend/src/database/users.go
@@ -358,3 +358,41 @@ func (db *DB) GetLoginEngagementActivity(userID *uint) (*models.LoginEngagementA
 
 	return result, nil
 }
+func (db *DB) GetEngagementActivityMetrics(userID *uint) (*models.EngagementActivityMetrics, error) {
+	var engagementActivityMetrics models.EngagementActivityMetrics
+
+	query := `SELECT 
+	    user_id,
+	    AVG(EXTRACT(EPOCH FROM (stop_ts - request_ts)) / 3600) AS avg_hours_active_monthly,
+	    SUM(
+	        CASE 
+	            WHEN request_ts >= date_trunc('week', CURRENT_DATE) 
+	            THEN EXTRACT(EPOCH FROM (stop_ts - request_ts)) / 3600
+	            ELSE 0 
+	        END
+	    ) AS total_hours_active_weekly,
+	    SUM(EXTRACT(EPOCH FROM duration) / 3600) AS total_hours_engaged,  
+	    MIN(request_ts) AS first_active_date,
+	    MAX(request_ts) AS last_active_date
+	FROM 
+	    open_content_activities
+	WHERE 
+	    request_ts >= CURRENT_DATE - INTERVAL '30 days'`
+
+	var args []interface{}
+
+	if userID != nil {
+		query += " AND user_id = ?"
+		args = append(args, *userID)
+	}
+
+	query += " GROUP BY user_id"
+
+	result := db.Raw(query, args...).Scan(&engagementActivityMetrics)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return &engagementActivityMetrics, nil
+}

--- a/backend/src/handlers/dashboard.go
+++ b/backend/src/handlers/dashboard.go
@@ -25,7 +25,6 @@ func (srv *Server) registerDashboardRoutes() []routeDef {
 }
 
 func (srv *Server) handleResidentProfile(w http.ResponseWriter, r *http.Request, log sLog) error {
-
 	queryParams := r.URL.Query()
 	var userID *uint
 
@@ -37,6 +36,9 @@ func (srv *Server) handleResidentProfile(w http.ResponseWriter, r *http.Request,
 		}
 		uid := uint(id)
 		userID = &uid
+
+		// Log the userID value
+		fmt.Printf("Extracted userID: %d\n", *userID)
 	}
 
 	loginData, err := srv.Db.GetLoginEngagementActivity(userID)
@@ -45,7 +47,21 @@ func (srv *Server) handleResidentProfile(w http.ResponseWriter, r *http.Request,
 		return err
 	}
 
-	return writeJsonResponse(w, http.StatusOK, loginData)
+	activityEngagement, err := srv.Db.GetEngagementActivityMetrics(userID)
+	if err != nil {
+		http.Error(w, "Failed to fetch activity engagement data", http.StatusInternalServerError)
+		return err
+	}
+
+	response := struct {
+		LoginEngagement    interface{} `json:"login_engagement"`
+		ActivityEngagement interface{} `json:"activity_engagement"`
+	}{
+		LoginEngagement:    loginData,
+		ActivityEngagement: activityEngagement,
+	}
+
+	return writeJsonResponse(w, http.StatusOK, response)
 }
 
 func (srv *Server) handleAdminLayer2(w http.ResponseWriter, r *http.Request, log sLog) error {

--- a/backend/src/models/logins.go
+++ b/backend/src/models/logins.go
@@ -45,10 +45,10 @@ type LoginEngagementActivity struct {
 }
 
 type EngagementActivityMetrics struct {
-	UserID                   uint      `json:"user_id"`
+	UserID                     uint      `json:"user_id"`
 	TotalHoursActiveLast30Days float64   `json:"total_hours_active_monthly"`
-	TotalHoursActiveThisWeek float64   `json:"total_hours_active_weekly"`
-	TotalHoursEngaged        float64   `json:"total_hours_engaged"`
-	FirstActiveDate          time.Time `json:"first_active_date"`
-	LastActiveDate           time.Time `json:"last_active_date"`
+	TotalHoursActiveThisWeek   float64   `json:"total_hours_active_weekly"`
+	TotalHoursEngaged          float64   `json:"total_hours_engaged"`
+	FirstActiveDate            time.Time `json:"first_active_date"`
+	LastActiveDate             time.Time `json:"last_active_date"`
 }

--- a/backend/src/models/logins.go
+++ b/backend/src/models/logins.go
@@ -43,3 +43,12 @@ type LoginActivityEntry struct {
 type LoginEngagementActivity struct {
 	PeakLoginTimes []LoginActivityEntry `json:"peak_login_times"`
 }
+
+type EngagementActivityMetrics struct {
+	UserID                   uint      `json:"user_id"`
+	TotalHoursActiveLast30Days float64   `json:"total_hours_active_monthly"`
+	TotalHoursActiveThisWeek float64   `json:"total_hours_active_weekly"`
+	TotalHoursEngaged        float64   `json:"total_hours_engaged"`
+	FirstActiveDate          time.Time `json:"first_active_date"`
+	LastActiveDate           time.Time `json:"last_active_date"`
+}

--- a/frontend/src/Pages/StudentProfile.tsx
+++ b/frontend/src/Pages/StudentProfile.tsx
@@ -1,7 +1,7 @@
 // import { useState } from 'react';
 import useSWR from 'swr';
 import { AxiosError } from 'axios';
-import { EngagementRateGraphProps, ServerResponseOne } from '@/common';
+import { ResidentEngagementProfile, ServerResponseOne } from '@/common';
 // import { ResponsiveContainer } from 'recharts';
 // import StatsCard from './StatsCard';
 import NewEngagementRateGraph from '@/Components/EngagementRateGraph';
@@ -9,20 +9,17 @@ import { ResponsiveContainer } from 'recharts';
 // import { useAuth } from '@/useAuth';
 import StatsCard from '@/Components/StatsCard';
 import { UserCircleIcon } from '@heroicons/react/24/outline';
+import { useParams } from 'react-router-dom';
 // TODO: figure out how to pass the studentId to this page
 const StudentProfile = () => {
     // const { user } = useAuth();
-    // const [facility, setFacility] = useState('all');
-    // const [days, setDays] = useState(7);
-    // const datimeInt =  {"time_interval": "2025-02-12T17:00:00Z",
-    // "total_logins": 1};
-
     // const [resetCache, setResetCache] = useState(false);
-
+    const { user_id } = useParams<{ user_id: string }>();
+    const uid = Number(user_id);
     const { data, error, isLoading } = useSWR<
-        ServerResponseOne<EngagementRateGraphProps>,
+        ServerResponseOne<ResidentEngagementProfile>,
         AxiosError
-    >(`/api/users/${1}/profile`);
+    >(`/api/users/${uid}/profile`);
     const metrics = data?.data;
 
     // const { data: facilitiesData } =
@@ -47,21 +44,21 @@ const StudentProfile = () => {
             {data && metrics && (
                 <>
                     {/* <div className="flex items-end justify-between pb-4">
-                        <div className="flex flex-row gap-4">
-                            
-                        </div>
-                        <div>
-                            <p className="label label-text text-grey-3">
-                                Last updated:
-                            </p>
-                            <button
-                                className="button justify-self-end"
-                                // onClick={() => setResetCache(!resetCache)}
-                            >
-                                Refresh Data
-                            </button>
-                        </div>
-                    </div> */}
+                         <div className="flex flex-row gap-4">
+                             
+                         </div>
+                         <div>
+                             <p className="label label-text text-grey-3">
+                                 Last updated:
+                             </p>
+                             <button
+                                 className="button justify-self-end"
+                                 // onClick={() => setResetCache(!resetCache)}
+                             >
+                                 Refresh Data
+                             </button>
+                         </div>
+                     </div> */}
 
                     <div className="flex flex-row gap-6">
                         <div className="w-1/5 flex flex-col gap-4">
@@ -85,8 +82,8 @@ const StudentProfile = () => {
                                         >
                                             <NewEngagementRateGraph
                                                 peak_login_times={
-                                                    metrics?.peak_login_times ??
-                                                    []
+                                                    metrics?.login_engagement
+                                                        .peak_login_times ?? []
                                                 }
                                                 viewType={'daily'}
                                             />
@@ -99,21 +96,25 @@ const StudentProfile = () => {
                     <div className="grid grid-cols-3 gap-4 mb-6 mt-6">
                         <StatsCard
                             title="Days Active"
-                            number={'2'}
+                            number={metrics.activity_engagement.total_hours_active_monthly.toString()}
                             label="Days Active This Month"
                             tooltip="Total number of days resident has been active in UnlockedEd"
                         />
                         <StatsCard
                             title="Average Hours"
-                            number={'1222'}
-                            label={`AVG Hours PER Week`}
-                            tooltip={`Average number of hours resident is logged in to UnlockedEd`}
+                            number={metrics.activity_engagement.total_hours_active_weekly.toString()}
+                            label={'AVG Hours PER Week'}
+                            tooltip={
+                                'Average number of hours resident is logged in to UnlockedEd'
+                            }
                         />
                         <StatsCard
                             title="Total Hours"
-                            number={'1555hrs'}
-                            label={`Total Hours This Week`}
-                            tooltip={`Total number of hours resident was logged in to UnlockedEd this week`}
+                            number={metrics.activity_engagement.total_hours_engaged.toString()}
+                            label={'Total Hours This Week'}
+                            tooltip={
+                                'Total number of hours resident was logged in to UnlockedEd this week'
+                            }
                         />
                     </div>
                 </>

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -740,3 +740,19 @@ export interface EngagementRateGraphProps {
     peak_login_times: PeakLoginTime[];
     viewType: 'hourly' | 'daily';
 }
+
+export interface EngagementActivityMetrics {
+    user_id: number;
+
+    total_hours_active_monthly: number;
+    total_hours_active_weekly: number;
+    total_hours_engaged: number;
+    first_active_date: string;
+    last_active_date: string;
+}
+
+// Unified interface that combines login and activity engagement
+export interface ResidentEngagementProfile {
+    login_engagement: EngagementRateGraphProps;
+    activity_engagement: EngagementActivityMetrics;
+}


### PR DESCRIPTION
## Description of the change

activity_engagement metrics. 
Bug tho, the raq sqw returns decimal values for fields for monthly, and weekly, but I cannot get it to show anything but zero on the page:

![image](https://github.com/user-attachments/assets/b519f54a-10ef-486d-a7df-22451a854fc5)
![image](https://github.com/user-attachments/assets/0d91bfe4-05d6-4d49-85a2-8986069d238f)

Raw Sql:
SELECT 
    user_id,
    AVG(EXTRACT(EPOCH FROM (stop_ts - request_ts)) / 3600) AS avg_hours_active_last_30_days,
    SUM(
        CASE 
            WHEN request_ts >= date_trunc('week', CURRENT_DATE) 
            THEN EXTRACT(EPOCH FROM (stop_ts - request_ts)) / 3600
            ELSE 0 
        END
    ) AS total_hours_active_this_week,
    SUM(duration) AS total_hours_engaged,  
    MIN(request_ts) AS first_active_date,
    MAX(request_ts) AS last_active_date
FROM 
    open_content_activities
WHERE 
    request_ts >= CURRENT_DATE - INTERVAL '30 days'
GROUP BY 
    user_id;

